### PR TITLE
Handle the case where there may be spaces in the player name

### DIFF
--- a/src/usr/local/etc/init.d/librespot
+++ b/src/usr/local/etc/init.d/librespot
@@ -19,7 +19,7 @@ case "$1" in
       fi
 
       start-stop-daemon --start --quiet --exec $DAEMON \
-        -- -n $NAME -b 160 --cache /tmp --initial-volume 20 --backend alsa --device $OUTPUT --volume-range 30 --quiet > /tmp/librespot.log 2>&1 &
+        -- -n "$NAME" -b 160 --cache /tmp --initial-volume 20 --backend alsa --device $OUTPUT --volume-range 30 --quiet > /tmp/librespot.log 2>&1 &
   ;;
   stop)
       echo "Stopping $DESC..."


### PR DESCRIPTION
If the player is setup with spaces in its name, then the init.d script will only name the Spotify player the first word from the name.